### PR TITLE
feat: #39292 - Add comp. LabelField and fix InputRoot

### DIFF
--- a/src/commons/types/index.ts
+++ b/src/commons/types/index.ts
@@ -1,0 +1,1 @@
+export type CommonSize = 'small' | 'medium' | 'large';

--- a/src/commons/variants/sizes.ts
+++ b/src/commons/variants/sizes.ts
@@ -1,0 +1,39 @@
+import { css } from '~/config/theme';
+
+export const variantFontSize = css({
+  defaultVariants: {
+    size: 'medium',
+  },
+  variants: {
+    size: {
+      large: {
+        fontSize: '$6',
+      },
+      medium: {
+        fontSize: '$4',
+      },
+      small: {
+        fontSize: '$2',
+      },
+    },
+  },
+});
+
+export const variantPadding = css({
+  defaultVariants: {
+    size: 'medium',
+  },
+  variants: {
+    size: {
+      large: {
+        padding: '$4',
+      },
+      medium: {
+        padding: '$3',
+      },
+      small: {
+        padding: '$2',
+      },
+    },
+  },
+});

--- a/src/components/InputRoot/index.tsx
+++ b/src/components/InputRoot/index.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
-import { Content, Error, Icon, InputContent, Label, Root } from './style';
+import { LabelField } from '../LabelField';
+import { Content, Error, Icon, InputContent, Root } from './style';
 import { Props } from './type';
 
 export const InputRoot: FC<Props> = ({
@@ -9,13 +10,19 @@ export const InputRoot: FC<Props> = ({
   disabled,
   elementId = 'input',
   errorText,
-  hasError,
+  hasError = false,
   icon,
+  infoText,
+  isRequired = false,
   label,
   size,
 }) => (
   <Root className={className} size={size}>
-    {label ? <Label htmlFor={elementId}>{label}</Label> : null}
+    {label ? (
+      <LabelField elementId={elementId} iconText={infoText} isOptional={!isRequired}>
+        {label}
+      </LabelField>
+    ) : null}
     <Content>
       <InputContent disabled={disabled} hasError={hasError}>
         {children}

--- a/src/components/InputRoot/stories.tsx
+++ b/src/components/InputRoot/stories.tsx
@@ -16,7 +16,7 @@ export default {
 } as ComponentMeta<typeof InputRoot>;
 
 const defaultArgs: Props = {
-  children: <div>{faker.lorem.words(2)}</div>,
+  children: faker.lorem.words(2),
   disabled: false,
   errorText: 'Text example of field error',
   hasError: false,
@@ -54,4 +54,17 @@ export const Disabled = Template.bind({});
 Disabled.args = {
   ...defaultArgs,
   disabled: true,
+};
+export const Required = Template.bind({});
+
+Required.args = {
+  ...defaultArgs,
+  isRequired: true,
+};
+
+export const Info = Template.bind({});
+
+Info.args = {
+  ...defaultArgs,
+  infoText: faker.lorem.paragraph(2),
 };

--- a/src/components/InputRoot/style.ts
+++ b/src/components/InputRoot/style.ts
@@ -1,44 +1,7 @@
 import { keyframes } from '@stitches/react';
 
-import { css, styled } from '~/config/theme';
-
-export const variantFontSize = css({
-  defaultVariants: {
-    size: 'medium',
-  },
-  variants: {
-    size: {
-      large: {
-        fontSize: '$6',
-      },
-      medium: {
-        fontSize: '$4',
-      },
-      small: {
-        fontSize: '$2',
-      },
-    },
-  },
-});
-
-export const variantPadding = css({
-  defaultVariants: {
-    size: 'medium',
-  },
-  variants: {
-    size: {
-      large: {
-        padding: '$4',
-      },
-      medium: {
-        padding: '$3',
-      },
-      small: {
-        padding: '$2',
-      },
-    },
-  },
-});
+import { variantFontSize, variantPadding } from '~/commons/variants/sizes';
+import { styled } from '~/config/theme';
 
 export const Label = styled('label', {
   marginBottom: '$1',

--- a/src/components/InputRoot/style.ts
+++ b/src/components/InputRoot/style.ts
@@ -3,10 +3,6 @@ import { keyframes } from '@stitches/react';
 import { variantFontSize, variantPadding } from '~/commons/variants/sizes';
 import { styled } from '~/config/theme';
 
-export const Label = styled('label', {
-  marginBottom: '$1',
-});
-
 export const Content = styled('div', {
   position: 'relative',
 });
@@ -19,10 +15,8 @@ export const InputContent = styled('div', {
   display: 'flex',
   justifyContent: 'space-between',
   outline: '2px solid transparent',
-  overflow: 'hidden',
   position: 'relative',
   transition: '$easeInOut02',
-  zIndex: 9,
 
   '&:hover, &:focus-within': {
     outlineColor: '$primary200',
@@ -45,7 +39,7 @@ export const InputContent = styled('div', {
       true: {
         border: '1px solid $error200',
 
-        '&:hover,&:focus-within': {
+        '&:hover, &:focus-within': {
           outlineColor: '$error200',
         },
       },
@@ -92,7 +86,7 @@ export const Error = styled('label', {
   top: '0',
   visibility: 'hidden',
   width: '100%',
-  zIndex: 0,
+  zIndex: -1,
 });
 
 export const Root = styled('div', variantFontSize, {

--- a/src/components/InputRoot/type.ts
+++ b/src/components/InputRoot/type.ts
@@ -9,6 +9,8 @@ export interface OwnProps {
   errorText?: string;
   hasError?: boolean;
   icon?: string | JSX.Element;
+  infoText?: string;
+  isRequired?: boolean;
   label?: string;
   size?: CommonSize;
 }

--- a/src/components/LabelField/index.tsx
+++ b/src/components/LabelField/index.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from 'react';
+import { FiInfo } from 'react-icons/fi';
+
+import { Tooltip } from '~/components/Tooltip';
+
+import { Icon, Optional, Root } from './style';
+import { Props } from './type';
+
+export const LabelField: FC<Props> = ({
+  children,
+  className,
+  elementId,
+  icon = <FiInfo />,
+  iconText,
+  isOptional,
+  optionalText = 'opcional',
+  size,
+}) => (
+  <Root className={className} htmlFor={elementId} size={size}>
+    {children}
+    {isOptional ? <Optional>{optionalText}</Optional> : null}
+    {icon && iconText ? (
+      <Icon>
+        <Tooltip description={iconText}>{icon}</Tooltip>
+      </Icon>
+    ) : null}
+  </Root>
+);

--- a/src/components/LabelField/index.tsx
+++ b/src/components/LabelField/index.tsx
@@ -13,7 +13,7 @@ export const LabelField: FC<Props> = ({
   icon = <FiInfo />,
   iconText,
   isOptional,
-  optionalText = 'opcional',
+  optionalText = '(opcional)',
   size,
 }) => (
   <Root className={className} htmlFor={elementId} size={size}>

--- a/src/components/LabelField/stories.tsx
+++ b/src/components/LabelField/stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { faker } from '@faker-js/faker';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { LabelField } from '.';
+import { Props } from './type';
+
+export default {
+  argTypes: {
+    icon: { control: { disable: true } },
+    iconText: { control: { type: 'text' } },
+    isOptional: { defaultValue: false },
+    size: { defaultValue: 'medium' },
+    value: { control: { type: 'text' } },
+  },
+  component: LabelField,
+  parameters: { layout: 'centered' },
+  title: 'Components/LabelField',
+} as ComponentMeta<typeof LabelField>;
+
+const defaultArgs: Props = {
+  children: faker.lorem.words(2),
+  elementId: 'label-storybook',
+};
+
+const Template: ComponentStory<typeof LabelField> = (args) => <LabelField {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = { ...defaultArgs };
+
+export const TooltipIcon = Template.bind({});
+
+TooltipIcon.args = { ...defaultArgs, iconText: faker.lorem.paragraph(2) };
+
+export const Optional = Template.bind({});
+
+Optional.args = { ...defaultArgs, isOptional: true };

--- a/src/components/LabelField/style.ts
+++ b/src/components/LabelField/style.ts
@@ -1,0 +1,19 @@
+import { variantFontSize } from '~/commons/variants/sizes';
+import { styled } from '~/config/theme';
+
+export const Root = styled('label', variantFontSize, {
+  alignItems: 'center',
+  display: 'flex',
+  marginBottom: '$1',
+
+  defaultVariants: { size: 'medium' },
+});
+
+export const Icon = styled('span', {
+  marginLeft: '$3',
+});
+
+export const Optional = styled('span', {
+  color: '$gray400',
+  marginLeft: '$3',
+});

--- a/src/components/LabelField/test.tsx
+++ b/src/components/LabelField/test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { faker } from '@faker-js/faker';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { LabelField } from '.';
+
+const mockRandomValues = () => {
+  const label = faker.name.prefix();
+  const iconText = faker.lorem.paragraph(2);
+  const optionalText = faker.lorem.word(1);
+  const childrenText = faker.lorem.words(3);
+  const elementId = faker.lorem.words(1);
+
+  return { childrenText, elementId, iconText, label, optionalText };
+};
+
+describe('LabelField', () => {
+  test('should show childrenText', () => {
+    const { childrenText, elementId } = mockRandomValues();
+    render(<LabelField elementId={elementId}>{childrenText}</LabelField>);
+
+    expect(screen.queryByText(childrenText)).toBeTruthy();
+  });
+
+  test('should show childrenText when click in elementIcon', async () => {
+    const { childrenText, elementId, iconText } = mockRandomValues();
+    render(
+      <LabelField elementId={elementId} iconText={iconText}>
+        {childrenText}
+      </LabelField>
+    );
+
+    const elementIcon = document.querySelector('[data-state="closed"]');
+
+    await act(async () => {
+      userEvent.click(elementIcon);
+    });
+
+    expect(elementIcon).toHaveAttribute('data-state', 'instant-open');
+  });
+
+  test('should show OptionalText when isOptional true', async () => {
+    const { childrenText, elementId, optionalText } = mockRandomValues();
+    render(
+      <LabelField elementId={elementId} isOptional optionalText={optionalText}>
+        {childrenText}
+      </LabelField>
+    );
+
+    expect(screen.queryByText(optionalText)).toBeTruthy();
+  });
+});

--- a/src/components/LabelField/type.ts
+++ b/src/components/LabelField/type.ts
@@ -4,12 +4,11 @@ import { CommonSize } from '~/commons/types';
 
 export interface OwnProps {
   className?: string;
-  disabled?: boolean;
-  elementId?: string;
-  errorText?: string;
-  hasError?: boolean;
-  icon?: string | JSX.Element;
-  label?: string;
+  elementId: string;
+  icon?: JSX.Element;
+  iconText?: string | JSX.Element;
+  isOptional?: boolean;
+  optionalText?: string;
   size?: CommonSize;
 }
 

--- a/src/components/NumberField/stories.tsx
+++ b/src/components/NumberField/stories.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import { faker } from '@faker-js/faker';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import { NumberField } from './index';
@@ -19,6 +20,7 @@ const defaultArgs: Props = {
   disabled: false,
   errorText: 'Text example of field error',
   hasError: false,
+  isRequired: false,
   label: 'Label',
   maxLength: 2,
   name: '',
@@ -81,4 +83,18 @@ export const Disabled = Template.bind({});
 Disabled.args = {
   ...defaultArgs,
   disabled: true,
+};
+
+export const TooltipInfo = Template.bind({});
+
+TooltipInfo.args = {
+  ...defaultArgs,
+  infoText: faker.lorem.paragraph(2),
+};
+
+export const Required = Template.bind({});
+
+Required.args = {
+  ...defaultArgs,
+  isRequired: true,
 };

--- a/src/components/RadioGroup/test.tsx
+++ b/src/components/RadioGroup/test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { RadioGroup } from '.';
@@ -21,7 +21,7 @@ describe('RadioGroup enabled', () => {
     expect(firstItemLabel).toBeInTheDocument();
   });
 
-  test('calls onChange prop when clicked on a not selected item', () => {
+  test('calls onChange prop when clicked on a not selected item', async () => {
     const items = [
       { label: 'Item 1', value: '1' },
       { label: 'Item 2', value: '2' },
@@ -33,7 +33,9 @@ describe('RadioGroup enabled', () => {
 
     const secondItemLabel = screen.getByText(items[1].label);
 
-    userEvent.click(secondItemLabel);
+    await act(async () => {
+      userEvent.click(secondItemLabel);
+    });
 
     expect(handleValueChange).toBeCalledTimes(1);
   });

--- a/src/components/TextAreaField/index.tsx
+++ b/src/components/TextAreaField/index.tsx
@@ -17,7 +17,7 @@ export const TextAreaField: FC<Props> = (props) => {
         name={props.name}
         onChange={props.onChange}
         placeholder={props.placeholder}
-        required={props.required}
+        required={props.isRequired}
         rows={props.rows}
         size={props.size}
         value={props.value}

--- a/src/components/TextAreaField/stories.tsx
+++ b/src/components/TextAreaField/stories.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import { faker } from '@faker-js/faker';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import { TextAreaField } from './index';
@@ -79,4 +80,18 @@ export const Disabled = Template.bind({});
 Disabled.args = {
   ...defaultArgs,
   disabled: true,
+};
+
+export const TooltipInfo = Template.bind({});
+
+TooltipInfo.args = {
+  ...defaultArgs,
+  infoText: faker.lorem.paragraph(2),
+};
+
+export const Required = Template.bind({});
+
+Required.args = {
+  ...defaultArgs,
+  isRequired: true,
 };

--- a/src/components/TextAreaField/style.ts
+++ b/src/components/TextAreaField/style.ts
@@ -1,4 +1,4 @@
-import { variantFontSize } from '~/components/InputRoot/style';
+import { variantFontSize } from '~/commons/variants/sizes';
 import { styled } from '~/config/theme';
 
 export const TextArea = styled('textarea', variantFontSize, {

--- a/src/components/TextAreaField/types.ts
+++ b/src/components/TextAreaField/types.ts
@@ -7,7 +7,6 @@ export interface OwnProps {
   name: string;
   onChange: ChangeEventHandler<HTMLTextAreaElement>;
   placeholder?: string;
-  required?: boolean;
   rows?: number;
   value?: string;
 }

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -17,7 +17,7 @@ export const TextField: FC<Props> = (props) => {
         name={props.name}
         onChange={props.onChange}
         placeholder={props.placeholder}
-        required={props.required}
+        required={props.isRequired}
         size={props.size}
         type={props.type}
         value={props.value}

--- a/src/components/TextField/stories.tsx
+++ b/src/components/TextField/stories.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import { faker } from '@faker-js/faker';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import { TextField } from './index';
@@ -79,4 +80,18 @@ export const Disabled = Template.bind({});
 Disabled.args = {
   ...defaultArgs,
   disabled: true,
+};
+
+export const TooltipInfo = Template.bind({});
+
+TooltipInfo.args = {
+  ...defaultArgs,
+  infoText: faker.lorem.paragraph(2),
+};
+
+export const Required = Template.bind({});
+
+Required.args = {
+  ...defaultArgs,
+  isRequired: true,
 };

--- a/src/components/TextField/style.ts
+++ b/src/components/TextField/style.ts
@@ -1,4 +1,4 @@
-import { variantFontSize, variantPadding } from '~/components/InputRoot/style';
+import { variantFontSize, variantPadding } from '~/commons/variants/sizes';
 import { styled } from '~/config/theme';
 
 export const Input = styled('input', variantFontSize, variantPadding, {

--- a/src/components/TextField/type.ts
+++ b/src/components/TextField/type.ts
@@ -9,7 +9,6 @@ export interface OwnProps {
   name: string;
   onChange: ChangeEventHandler<HTMLInputElement>;
   placeholder?: string;
-  required?: boolean;
   type?: InputType;
   value?: string | number;
 }

--- a/src/components/Tooltip/style.ts
+++ b/src/components/Tooltip/style.ts
@@ -29,7 +29,6 @@ export const TooltipPortal = styled(Portal, {
   display: 'flex',
   flex: 1,
   flexDirection: 'column',
-  position: 'relative',
 });
 
 const revealByOpacity = keyframes({

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export { Button } from './Button';
+export { LabelField } from './LabelField';
 export { NumberField } from './NumberField';
 export { Switch } from './Switch';
 export { TextAreaField } from './TextAreaField';

--- a/src/config/globalStyles.ts
+++ b/src/config/globalStyles.ts
@@ -1,15 +1,18 @@
 import { globalCss } from './theme';
 
 export const globalStyles = globalCss({
-  '*, &::after, &::before': {
-    boxSizing: 'border-box',
-  },
+  '@import': "url('https://fonts.googleapis.com/css2?family=Roboto&display=swap')",
 
   ':root': {
     fontSize: '62.5%',
   },
 
+  '*, &::after, &::before': {
+    boxSizing: 'border-box',
+  },
+
   body: {
+    fontFamily: '$roboto',
     margin: 0,
     maxWidth: '100%',
     minHeight: '100%',

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -66,7 +66,6 @@ export const { config, createTheme, css, getCssText, globalCss, styled, theme } 
       6: '2.8rem',
       7: '3.2rem',
     },
-
     media: {
       lg: '(min-width: 1200px)',
       md: '(min-width: 900px)',


### PR DESCRIPTION
feat: #39292 - Add comp. LabelField
- Add folder commons, to organize/reuse patterns in multiple components;
- variantFontSize, variantPadding was moved to commons/variants;
- Add LabelField storybook and tests;
- Add @import of font Roboto in globalStyles;


feat: #39292 - Insere LabelField em InputRoot
- Add LabelField into InputRoot;
- Affected components: NumberField, TextField, TextArea, Select, MultiSelect;
- InfoText props can active Tooltip message in InputRoot and merges;
- Remove overflow from InputContent to avoid conflict with input childs and zIndex was fixed because of a bug with tooltip;

fix: #39292 - Add await act in radio test